### PR TITLE
Update chapter 1&2 titles in toc

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -90,8 +90,8 @@ knitr::include_graphics("images/me.png")
 
 # Contents{-}
 
-- [Chapter 1: What is a p-value](#pvalue)
-- [Chapter 2: What is power](#power)
+- [Chapter 1: *p*-values](#pvalue)
+- [Chapter 2: Sample size justification](#power)
 - [Chapter 3: Asking statistical questions](#questions)
 - [Chapter 4: Error control](#errorcontrol)
 - [Chapter 5: Effect sizes and Confidence Intervals](#effectsizeCI)


### PR DESCRIPTION
Hey, I noticed that the title of the first two chapters in the table of contents do not match the actual title of the chapters. I haven't re-built the output.